### PR TITLE
Add LPC support for TMC22XX drivers

### DIFF
--- a/src/LPC/BoardConfig.cpp
+++ b/src/LPC/BoardConfig.cpp
@@ -79,6 +79,9 @@ static const boardConfigEntry_t boardConfigs[]=
     
     {"lpc.adcEnablePreFilter", &ADCEnablePreFilter, nullptr, cvBoolType},
     
+#if LPC_TMC_SOFT_UART
+    {"stepper.TmcUartPins", TMC_UART_PINS, &MaxTotalDrivers, cvPinType},
+#endif
 };
 
 

--- a/src/LPC/Pins_LPC.cpp
+++ b/src/LPC/Pins_LPC.cpp
@@ -38,6 +38,9 @@ Pin DiagPin = NoPin;
 Pin ENABLE_PINS[NumDirectDrivers] =     {NoPin, NoPin, NoPin, NoPin, NoPin};
 Pin STEP_PINS[NumDirectDrivers] =       {NoPin, NoPin, NoPin, NoPin, NoPin};
 Pin DIRECTION_PINS[NumDirectDrivers] =  {NoPin, NoPin, NoPin, NoPin, NoPin};
+#if LPC_TMC_SOFT_UART
+    Pin TMC_UART_PINS[NumDirectDrivers] = {NoPin, NoPin, NoPin, NoPin, NoPin};
+#endif
 uint32_t STEP_DRIVER_MASK = 0;                          //SD: mask of the step pins on Port 2 used for writing to step pins in parallel
 bool hasStepPinsOnDifferentPorts = false;               //for boards that don't have all step pins on port2
 bool hasDriverCurrentControl = false;                   //Supports digipots to set stepper current

--- a/src/LPC/Pins_LPC.h
+++ b/src/LPC/Pins_LPC.h
@@ -86,7 +86,14 @@
 
 // The physical capabilities of the machine
 constexpr size_t NumDirectDrivers = 5;               // The maximum number of drives supported by the electronics
-constexpr size_t MaxSmartDrivers = 0;                // The maximum number of smart drivers
+#if defined(SUPPORT_TMC22xx)
+    constexpr size_t MaxSmartDrivers = 5;            // The maximum number of smart drivers
+    constexpr size_t NumTmcDriversSenseChannels = 2;
+    #define LPC_TMC_SOFT_UART 1
+#else
+    constexpr size_t MaxSmartDrivers = 0;            // The maximum number of smart drivers
+    #define LPC_TMC_SOFT_UART 0
+#endif
 
 constexpr size_t MaxSensors = 32;
 
@@ -123,6 +130,14 @@ constexpr unsigned int MaxTriggers = 16;            // Must be <= 32 because we 
 extern Pin ENABLE_PINS[NumDirectDrivers];
 extern Pin STEP_PINS[NumDirectDrivers];
 extern Pin DIRECTION_PINS[NumDirectDrivers];
+#if LPC_TMC_SOFT_UART
+    extern Pin TMC_UART_PINS[NumDirectDrivers];
+    constexpr Pin GlobalTmc22xxEnablePin = NoPin;			// The pin that drives ENN of all drivers
+    constexpr uint32_t DriversBaudRate = 9600;
+    constexpr uint32_t TransferTimeout = 100;				// any transfer should complete within 100 ticks @ 1ms/tick
+
+#endif
+
 extern uint32_t STEP_DRIVER_MASK; // Mask for parallel write to all steppers on port 2 (calculated in after loading board.txt)
 extern bool hasStepPinsOnDifferentPorts;
 extern bool hasDriverCurrentControl;

--- a/src/Movement/StepperDrivers/TMC22xx.cpp
+++ b/src/Movement/StepperDrivers/TMC22xx.cpp
@@ -15,8 +15,10 @@
 #include "Movement/StepTimer.h"
 #include "Hardware/Cache.h"
 
+#if !LPC_TMC_SOFT_UART
 #include "sam/drivers/pdc/pdc.h"
 #include "sam/drivers/uart/uart.h"
+#endif
 
 // Important note:
 // The TMC2224 does handle a write request immediately followed by a read request.
@@ -236,6 +238,8 @@ static constexpr uint8_t InitialSendCRC = CRCAddByte(CRCAddByte(0, 0x05), 0x00);
 // CRC of a request to read the IFCOUNT register
 static constexpr uint8_t ReadIfcountCRC = CRCAddByte(InitialSendCRC, REGNUM_IFCOUNT);
 
+
+
 //----------------------------------------------------------------------------------------------------------------------------------
 // Private types and methods
 
@@ -287,7 +291,7 @@ private:
 #if TMC22xx_HAS_MUX
 	void SetUartMux() noexcept;
 	static void SetupDMASend(uint8_t regnum, uint32_t outVal, uint8_t crc) noexcept __attribute__ ((hot));	// set up the PDC to send a register
-	static void SetupDMAReceive(uint8_t regnum, uint8_t crc) noexcept __attribute__ ((hot));					// set up the PDC to receive a register
+	static void SetupDMAReceive(uint8_t regnum, uint8_t crc) noexcept __attribute__ ((hot));				// set up the PDC to receive a register
 #else
 	void SetupDMASend(uint8_t regnum, uint32_t outVal, uint8_t crc) noexcept __attribute__ ((hot));			// set up the PDC to send a register
 	void SetupDMAReceive(uint8_t regnum, uint8_t crc) noexcept __attribute__ ((hot));						// set up the PDC to receive a register
@@ -325,8 +329,9 @@ private:
 	uint32_t microstepShiftFactor;							// how much we need to shift 1 left by to get the current microstepping
 	uint32_t motorCurrent;									// the configured motor current
 	uint32_t maxOpenLoadStepInterval;						// the maximum step pulse interval for which we consider open load detection to be reliable
+#if LPC_TMC_SOFT_UART
 
-#if TMC22xx_HAS_MUX
+#elif TMC22xx_HAS_MUX
 	static Uart * const uart;								// the UART that controls all drivers
 #else
 	Uart *uart;												// the UART that controls this driver
@@ -362,6 +367,237 @@ Uart * const TmcDriverState::uart = UART_TMC22xx;
 
 TmcDriverState * volatile TmcDriverState::currentDriver = nullptr;	// volatile because the ISR changes it
 uint32_t TmcDriverState::transferStartedTime;
+
+// Soft UART implementation
+#if LPC_TMC_SOFT_UART
+constexpr uint32_t SU_BAUD_RATE = DriversBaudRate;
+enum class SUStates
+{
+	idle,
+	writeSync,
+	writing,
+	readSync,
+	reading,
+	complete,
+	error
+};
+static uint32_t SUPeriod;
+static volatile uint32_t SUWriteCnt = 0;
+static volatile uint32_t SUReadCnt = 0;
+static volatile uint8_t *SUWritePtr;
+static volatile uint8_t *SUReadPtr;
+static volatile int SUBitCnt;
+static volatile uint32_t SUData;
+static volatile Pin SUPin;
+static LPC_GPIO_T *SUPort;
+static uint8_t SUPinNo;
+static volatile int SUOffset;
+static volatile int SUBaseOffset;
+static volatile SUStates SUState = SUStates::idle;
+
+
+
+
+extern "C" void RIT_IRQHandler() noexcept __attribute__ ((hot));
+
+void RIT_IRQHandler() noexcept
+{
+	Chip_RIT_ClearInt(LPC_RITIMER);
+	switch(SUState)
+	{
+	case SUStates::idle:
+		break;
+	case SUStates::writeSync:
+		{
+			// First four bits of a write are used to establish the baud rate for the connection.
+			// We record the actual time that the bits are written and use this to adjust the timing of
+			// the rest of the write and read operations. This reduces framing errors.
+			// First write the data
+			util_UpdateBit(SUPort->PIN, SUPinNo, SUData & 1);
+			int offset = Chip_RIT_GetCounter(LPC_RITIMER);
+			SUData >>= 1;
+			if (++SUBitCnt == 1)
+				// record time offset of first bit
+				SUBaseOffset = offset;
+			else if (SUBitCnt == 5)
+			{
+				// caclculate per bit timing offset for sync sequence 
+				SUOffset = (offset - SUBaseOffset)/4;
+				// adjust timing for rest of write operation
+				Chip_RIT_SetCOMPVAL(LPC_RITIMER, SUPeriod + SUOffset);
+				// Sync complete
+				SUState = SUStates::writing;	
+			}
+			break;
+		}
+
+	case SUStates::writing:
+    	if (++SUBitCnt <= 10 ) 
+		{
+			// send data 
+			util_UpdateBit(SUPort->PIN, SUPinNo, SUData & 1);
+			SUData >>= 1;
+    	}
+    	else if (--SUWriteCnt > 0)
+		{
+			// send start bit of next byte
+			util_UpdateBit(SUPort->PIN, SUPinNo, 0);
+			// get data and add stop bit (but not start bit as we have already handled that)
+			SUData = 0x100 | *SUWritePtr++;
+			// Start bit has already been sent
+			SUBitCnt = 1;
+		}
+		else
+		{
+			// end of output, switch to input mode
+			util_UpdateBit(SUPort->DIR, SUPinNo, 0);
+			// TMC22XX will start sending data 8 bits after the write completes
+			Chip_RIT_SetCOMPVAL(LPC_RITIMER, (SUPeriod + SUOffset)*8);
+			SUState = SUStates::readSync;
+		}
+		break;
+	case SUStates::readSync:
+		{
+			uint8_t inbit = util_IsBitSet(SUPort->PIN, SUPinNo);
+			// Do we have the start bit?
+			if (!inbit) 
+			{
+				// got start bit, set timing for reading bits
+				Chip_RIT_SetCOMPVAL(LPC_RITIMER, SUPeriod + SUOffset);
+				SUBitCnt = 1;
+				SUData = 0;
+				SUState = SUStates::reading;
+			}
+			else
+				// no start bit, give up
+				SUState = SUStates::error;
+			break;
+		}
+	case SUStates::reading:
+		if (++SUBitCnt <= 9)
+		{
+			// data bits, read data
+			uint8_t inbit = util_IsBitSet(SUPort->PIN, SUPinNo);
+      		SUData >>= 1;
+      		if (inbit)
+        		SUData |= 0x80;
+		}
+		else
+		{
+			// Stop bit read, store data byte in buffer
+			*SUReadPtr++ =  static_cast<uint8_t>(SUData);
+			if (--SUReadCnt <= 0)
+				SUState = SUStates::complete;
+			else
+				SUState = SUStates::readSync;		
+		}
+		break;
+	case SUStates::complete:
+	case SUStates::error:		
+		Chip_RIT_Disable(LPC_RITIMER);
+		break;			
+	}
+}	
+
+static void LPCSoftUARTAbort() noexcept
+{
+	Chip_RIT_Disable(LPC_RITIMER);
+	SUReadCnt = 0;
+	SUWriteCnt = 0;
+	SUState = SUStates::idle;
+	if (SUPin != NoPin)
+		pinMode(SUPin, INPUT_PULLUP);
+}
+
+static void LPCSoftUARTStartTransfer(uint8_t driver, volatile uint8_t *WritePtr, uint32_t WriteCnt, volatile uint8_t *ReadPtr, uint32_t ReadCnt) noexcept
+{
+	LPCSoftUARTAbort();
+	SUPin = TMC_UART_PINS[driver];
+	if (SUPin != NoPin)
+	{
+		// got valid Pin so set things up for transfer
+		LPC_RITIMER->COUNTER = 0;
+		Chip_RIT_SetCOMPVAL(LPC_RITIMER, SUPeriod);
+		SUWritePtr = WritePtr;
+		SUReadPtr = ReadPtr;
+		// Add start and stop bits to first byte
+		SUData = (static_cast<uint32_t>(*SUWritePtr) << 1) | 0x200;
+		SUWritePtr++;
+		SUBitCnt = 0;
+		SUOffset = 0;
+		pinMode(SUPin, OUTPUT_HIGH);
+		// use direct access to keep interupt handler as fast as possible
+		SUPort = (LPC_GPIO_T*)(LPC_GPIO0_BASE + ((SUPin) & ~0x1f));
+		SUPinNo = SUPin & 0x1f;
+		SUWriteCnt = WriteCnt;
+		SUReadCnt = ReadCnt;
+		SUState = SUStates::writeSync;
+		Chip_RIT_Enable(LPC_RITIMER);
+	}
+}
+
+
+static void LPCSoftUARTCheckComplete() noexcept
+{
+	if (SUState == SUStates::complete)
+	{
+		SUState = SUStates::idle;
+		// I/O complete
+		TmcDriverState *driver = TmcDriverState::currentDriver;	// capture volatile variable
+		if (driver != nullptr)
+		{
+			driver->UartTmcHandler();
+		}
+	}
+}
+
+static void LPCSoftUARTInit() noexcept
+{
+	Chip_RIT_Init(LPC_RITIMER);
+	SUPeriod = Chip_Clock_GetPeripheralClockRate(SYSCTL_PCLK_RIT)/(SU_BAUD_RATE);
+	Chip_RIT_SetCOMPVAL(LPC_RITIMER, SUPeriod);
+
+	Chip_RIT_EnableCTRL(LPC_RITIMER, RIT_CTRL_ENCLR);
+
+	for(size_t i = 0; i < NumDirectDrivers; i++)
+		if (TMC_UART_PINS[i] != NoPin)
+			pinMode(TMC_UART_PINS[i], INPUT_PULLUP);
+
+	SUPin = NoPin;
+	SUState = SUStates::idle;
+	NVIC_EnableIRQ(RITIMER_IRQn);
+}
+
+
+static void LPCSoftUARTShutdown() noexcept
+{
+	LPCSoftUARTAbort();
+	NVIC_DisableIRQ(RITIMER_IRQn);
+}
+
+// When using a soft UART other interrupts or disabling interrupts for a length of time can easily
+// create errors. Because of this it is likely that we will read corrupt data from time to time. 
+// We add an extra layer of data validation by always checking the CRC of the entire packet as
+// well as the normal checks.
+uint8_t static calcCRC(volatile uint8_t *datagram, uint8_t len) {
+	uint8_t crc = 0;
+	for (uint8_t i = 0; i < len; i++) {
+		uint8_t currentByte = datagram[i];
+		for (uint8_t j = 0; j < 8; j++) {
+			if ((crc >> 7) ^ (currentByte & 0x01)) {
+				crc = (crc << 1) ^ 0x07;
+			} else {
+				crc = (crc << 1);
+			}
+			crc &= 0xff;
+			currentByte = currentByte >> 1;
+		}
+	}
+	return crc;
+}
+
+
+#endif
 
 // To write a register, we send one 8-byte packet to write it, then a 4-byte packet to ask for the IFCOUNT register, then we receive an 8-byte packet containing IFCOUNT.
 // This is the message we send - volatile because we care about when it is written
@@ -408,12 +644,15 @@ const uint8_t TmcDriverState::ReadRegCRCs[NumReadRegisters] =
 // State structures for all drivers
 static TmcDriverState driverStates[MaxSmartDrivers];
 
+
 // Set up the PDC to send a register
 inline void TmcDriverState::SetupDMASend(uint8_t regNum, uint32_t regVal, uint8_t crc) noexcept
 {
+#if !LPC_TMC_SOFT_UART
 	// Faster code, not using the ASF
 	Pdc * const pdc = uart_get_pdc_base(uart);
 	pdc->PERIPH_PTCR = (PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);	// disable the PDC
+#endif
 
 	sendData[2] = regNum | 0x80;
 	sendData[3] = (uint8_t)(regVal >> 24);
@@ -421,7 +660,9 @@ inline void TmcDriverState::SetupDMASend(uint8_t regNum, uint32_t regVal, uint8_
 	sendData[5] = (uint8_t)(regVal >> 8);
 	sendData[6] = (uint8_t)regVal;
 	sendData[7] = crc;
-
+#if LPC_TMC_SOFT_UART
+	LPCSoftUARTStartTransfer(driverNumber, sendData, 12, receiveData + 12, 8);
+#else
 	Cache::FlushBeforeDMASend(sendData, sizeof(sendData));
 	Cache::FlushBeforeDMAReceive(receiveData, sizeof(receiveData));
 
@@ -432,18 +673,24 @@ inline void TmcDriverState::SetupDMASend(uint8_t regNum, uint32_t regVal, uint8_
 	pdc->PERIPH_RCR = 20;											// number of bytes to receive: the sent data + 8 bytes of received data
 
 	pdc->PERIPH_PTCR = (PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN);		// enable the PDC to transmit and receive
+#endif
 }
 
 // Set up the PDC to send a register and receive the status
 inline void TmcDriverState::SetupDMAReceive(uint8_t regNum, uint8_t crc) noexcept
 {
+#if !LPC_TMC_SOFT_UART
 	// Faster code, not using the ASF
 	Pdc * const pdc = uart_get_pdc_base(uart);
 	pdc->PERIPH_PTCR = (PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);	// disable the PDC
+#endif
 
 	sendData[2] = regNum;
 	sendData[3] = crc;
 
+#if LPC_TMC_SOFT_UART
+	LPCSoftUARTStartTransfer(driverNumber, sendData, 4, receiveData + 4, 8);
+#else
 	Cache::FlushBeforeDMASend(sendData, sizeof(sendData));
 	Cache::FlushBeforeDMAReceive(receiveData, sizeof(receiveData));
 
@@ -454,7 +701,9 @@ inline void TmcDriverState::SetupDMAReceive(uint8_t regNum, uint8_t crc) noexcep
 	pdc->PERIPH_RCR = 12;											// receive the 4 bytes we sent + 8 bytes of received data
 
 	pdc->PERIPH_PTCR = (PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN);		// enable the PDC to transmit and receive
+#endif
 }
+
 
 // Update the maximum step pulse interval at wich we consider open load detection to be reliable
 void TmcDriverState::UpdateMaxOpenLoadStepInterval() noexcept
@@ -517,7 +766,7 @@ pre(!driversPowered)
 		pinMode(p_pin, OUTPUT_HIGH);
 	}
 
-#if !TMC22xx_HAS_MUX
+#if !TMC22xx_HAS_MUX && !LPC_TMC_SOFT_UART
 	uart = TMC22xxUarts[p_driverNumber];
 #endif
 
@@ -777,10 +1026,10 @@ void TmcDriverState::AppendDriverStatus(const StringRef& reply) noexcept
 	{
 		reply.cat(" ok");
 	}
-
 	reply.catf(", read errors %u, write errors %u, ifcount %u, reads %u, timeouts %u", readErrors, writeErrors, lastIfCount, numReads, numTimeouts);
 	readErrors = writeErrors = numReads = numTimeouts = 0;
 }
+
 
 // This is called by the ISR when the SPI transfer has completed
 inline void TmcDriverState::TransferDone() noexcept
@@ -789,7 +1038,11 @@ inline void TmcDriverState::TransferDone() noexcept
 	if (sendData[2] & 0x80)								// if we were writing a register
 	{
 		const uint8_t currentIfCount = receiveData[18];
+#if LPC_TMC_SOFT_UART
+		if (currentIfCount == (uint8_t)(lastIfCount + 1) && calcCRC(receiveData+12, 7) == receiveData[19])
+#else
 		if (currentIfCount == (uint8_t)(lastIfCount + 1))
+#endif
 		{
 			registersToUpdate &= ~registerBeingUpdated;
 		}
@@ -801,7 +1054,11 @@ inline void TmcDriverState::TransferDone() noexcept
 	}
 	else if (driversState != DriversState::noPower)		// we don't check the CRC, so only accept the result if power is still good
 	{
+#if LPC_TMC_SOFT_UART
+		if (sendData[2] == ReadRegNumbers[registerToRead] && ReadRegNumbers[registerToRead] == receiveData[6] && receiveData[4] == 0x05 && receiveData[5] == 0xFF && calcCRC(receiveData+4, 7) == receiveData[11])
+#else
 		if (sendData[2] == ReadRegNumbers[registerToRead] && ReadRegNumbers[registerToRead] == receiveData[6] && receiveData[4] == 0x05 && receiveData[5] == 0xFF)
+#endif
 		{
 			// We asked to read the scheduled read register, and the sync byte, slave address and register number in the received message match
 			//TODO here we could check the CRC of the received message, but for now we assume that we won't get any corruption in the 32-bit received data
@@ -838,9 +1095,13 @@ inline void TmcDriverState::TransferDone() noexcept
 // This is called to abandon the current transfer, if any
 void TmcDriverState::AbortTransfer() noexcept
 {
+#if LPC_TMC_SOFT_UART
+	LPCSoftUARTAbort();
+#else
 	uart->UART_IDR = UART_IDR_ENDRX;				// disable end-of-receive interrupt
 	uart_get_pdc_base(uart)->PERIPH_PTCR = (PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);	// disable the PDC
 	uart->UART_CR = UART_CR_RSTRX | UART_CR_RSTTX | UART_CR_RXDIS | UART_CR_TXDIS | UART_CR_RSTSTA;
+#endif
 }
 
 #if TMC22xx_HAS_MUX
@@ -892,10 +1153,14 @@ inline void TmcDriverState::StartTransfer() noexcept
 
 		// Read a register
 		const irqflags_t flags = cpu_irq_save();		// avoid race condition
+#if LPC_TMC_SOFT_UART
+		SetupDMAReceive(ReadRegNumbers[registerToRead], ReadRegCRCs[registerToRead]);	// set up the PDC
+#else
 		uart->UART_CR = UART_CR_RSTRX | UART_CR_RSTTX;	// reset transmitter and receiver
 		SetupDMAReceive(ReadRegNumbers[registerToRead], ReadRegCRCs[registerToRead]);	// set up the PDC
 		uart->UART_IER = UART_IER_ENDRX;				// enable end-of-receive interrupt
 		uart->UART_CR = UART_CR_RXEN | UART_CR_TXEN;	// enable transmitter and receiver
+#endif
 		transferStartedTime = millis();
 		cpu_irq_restore(flags);
 	}
@@ -907,10 +1172,14 @@ inline void TmcDriverState::StartTransfer() noexcept
 		// Kick off a transfer for that register
 		const irqflags_t flags = cpu_irq_save();		// avoid race condition
 		registerBeingUpdated = 1u << regNum;
+#if LPC_TMC_SOFT_UART
+		SetupDMASend(WriteRegNumbers[regNum], writeRegisters[regNum], writeRegCRCs[regNum]);	// set up the PDC
+#else
 		uart->UART_CR = UART_CR_RSTRX | UART_CR_RSTTX;	// reset transmitter and receiver
 		SetupDMASend(WriteRegNumbers[regNum], writeRegisters[regNum], writeRegCRCs[regNum]);	// set up the PDC
 		uart->UART_IER = UART_IER_ENDRX;				// enable end-of-transfer interrupt
 		uart->UART_CR = UART_CR_RXEN | UART_CR_TXEN;	// enable transmitter and receiver
+#endif
 		transferStartedTime = millis();
 		cpu_irq_restore(flags);
 	}
@@ -920,7 +1189,9 @@ inline void TmcDriverState::StartTransfer() noexcept
 
 inline void TmcDriverState::UartTmcHandler() noexcept
 {
+#if !LPC_TMC_SOFT_UART
 	uart->UART_IDR = UART_IDR_ENDRX;					// disable the PDC interrupt
+#endif
 	TransferDone();										// tidy up after the transfer we just completed
 	if (driversState != DriversState::noPower)
 	{
@@ -958,7 +1229,7 @@ void TMC22xx_UART_Handler() noexcept
 	}
 }
 
-#else
+#elif !LPC_TMC_SOFT_UART
 
 // ISRs for the individual UARTs
 extern "C" void UART_TMC_DRV0_Handler() noexcept __attribute__ ((hot));
@@ -986,9 +1257,9 @@ namespace SmartDrivers
 		numTmc22xxDrivers = min<size_t>(numTmcDrivers, MaxSmartDrivers);
 
 		// Make sure the ENN pins are high
-		pinMode(GlobalTmc22xxEnablePin, OUTPUT_HIGH);
-
-#if TMC22xx_HAS_MUX
+#if LPC_TMC_SOFT_UART
+		LPCSoftUARTInit();
+#elif TMC22xx_HAS_MUX
 		// Set up- the single UART that communicates with all TMC22xx drivers
 		ConfigurePin(TMC22xx_UART_PINS);									// the pins are already set up for UART use in the pins table
 
@@ -1012,7 +1283,7 @@ namespace SmartDrivers
 		driversState = DriversState::noPower;
 		for (size_t drive = 0; drive < numTmc22xxDrivers; ++drive)
 		{
-#if !TMC22xx_HAS_MUX
+#if !TMC22xx_HAS_MUX && !LPC_TMC_SOFT_UART
 			// Initialise the UART that controls this driver
 			// The pins are already set up for UART use in the pins table
 			ConfigurePin(TMC22xxUartPins[drive]);
@@ -1036,8 +1307,11 @@ namespace SmartDrivers
 	// Shut down the drivers and stop any related interrupts. Don't call Spin() again after calling this as it may re-enable them.
 	void Exit() noexcept
 	{
-		pinMode(GlobalTmc22xxEnablePin, OUTPUT_HIGH);
-#if TMC22xx_HAS_MUX
+		if (GlobalTmc22xxEnablePin != NoPin)
+			pinMode(GlobalTmc22xxEnablePin, OUTPUT_HIGH);
+#if LPC_TMC_SOFT_UART
+		LPCSoftUARTShutdown();
+#elif TMC22xx_HAS_MUX
 		NVIC_DisableIRQ(TMC22xx_UART_IRQn);
 #else
 		for (size_t drive = 0; drive < numTmc22xxDrivers; ++drive)
@@ -1129,6 +1403,9 @@ namespace SmartDrivers
 	// Before the first call to this function with 'powered' true, you must call Init()
 	void Spin(bool powered) noexcept
 	{
+	#if LPC_TMC_SOFT_UART
+		LPCSoftUARTCheckComplete();
+	#endif
 		if (driversState == DriversState::noPower)
 		{
 			if (powered)
@@ -1185,7 +1462,8 @@ namespace SmartDrivers
 
 				if (allInitialised)
 				{
-					digitalWrite(GlobalTmc22xxEnablePin, LOW);
+					if (GlobalTmc22xxEnablePin != NoPin)
+						digitalWrite(GlobalTmc22xxEnablePin, LOW);
 					driversState = DriversState::ready;
 				}
 			}
@@ -1193,7 +1471,8 @@ namespace SmartDrivers
 		else
 		{
 			// We had power but we lost it
-			digitalWrite(GlobalTmc22xxEnablePin, HIGH);			// disable the drivers
+			if (GlobalTmc22xxEnablePin != NoPin)
+				digitalWrite(GlobalTmc22xxEnablePin, HIGH);			// disable the drivers
 			if (TmcDriverState::currentDriver == nullptr)
 			{
 				TmcDriverState::currentDriver->AbortTransfer();

--- a/src/Movement/StepperDrivers/TMC22xx.h
+++ b/src/Movement/StepperDrivers/TMC22xx.h
@@ -12,8 +12,8 @@
 
 #if SUPPORT_TMC22xx
 
-#ifndef TMC22xx_HAS_MUX
-# error TMC22xx_HAS_MUX not defined
+#if !defined(TMC22xx_HAS_MUX) && !defined(LPC_TMC_SOFT_UART)
+# error TMC22xx_HAS_MUX/LPC_TMC_SOFT_UART not defined
 #endif
 
 #include "RepRapFirmware.h"

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -423,6 +423,8 @@ void Platform::Init() noexcept
 	numSmartDrivers = MaxSmartDrivers;
 # elif defined(DUET3)
 	numSmartDrivers = MaxSmartDrivers;
+# elif defined(__LPC17xx__)
+	numSmartDrivers = MaxSmartDrivers;
 # endif
 #endif
 
@@ -1407,7 +1409,9 @@ void Platform::InitialiseInterrupts() noexcept
 #endif
 
 #if SUPPORT_TMC22xx
-# if TMC22xx_HAS_MUX
+# if LPC_TMC_SOFT_UART
+	NVIC_SetPriority(RITIMER_IRQn, NvicPriorityDriversSerialTMC);		// set priority for Soft UART timer
+# elif TMC22xx_HAS_MUX
 	NVIC_SetPriority(TMC22xx_UART_IRQn, NvicPriorityDriversSerialTMC);	// set priority for TMC2660 SPI interrupt
 # else
 	NVIC_SetPriority(TMC22xxUartIRQns[0], NvicPriorityDriversSerialTMC);
@@ -3903,6 +3907,8 @@ float Platform::GetTmcDriversTemperature(unsigned int board) const noexcept
 	const uint16_t mask = LowestNBits<uint16_t>(5);					// all drivers (0-4) are on the DueX, no further expansion supported
 #elif defined(PCCB_08)
 	const uint16_t mask = LowestNBits<uint16_t>(2);					// drivers 0, 1 are on-board, no expansion supported
+#elif defined(__LPC17xx__)
+	const uint16_t mask = LowestNBits<uint16_t>(MaxSmartDrivers);	// All drivers
 #endif
 	return ((temperatureShutdownDrivers & mask) != 0) ? 150.0
 			: ((temperatureWarningDrivers & mask) != 0) ? 100.0


### PR DESCRIPTION
This adds support for TMC22XX drivers when using LPC based systems. It
uses the LPC Repetitive Interrupt Timer (RIT) to drive a custom software
UART implemetation. This allows the use of standard GPIO pins to talk to
UART based TMC devices. A single pin is used per device and the UART
operates in half duplex mode. To minimise system impact the UART
operates at a slow speed (9600 baud) and uses a single interrupt per
bit. When the UART is not operating the timer is disabled. The interrupt
handler takes approximately 1uS to execute on an LPC1768 (plus standard
interrupt overhead).

Potential issues
When enabled all active drivers must be TMC22XX devices.

The software UART is sensitive to timing issues. If other parts of the
system delay the RIT interrupt handler then errors will occur. To
improve detection of these errors full CRC checking of responses has
been enabled. Currently no errors are seen when the system is idle, but
during test print jobs an error rate of 0.5% is seen. If there is an
error the operation will be retried. Currently RepRap
firmware polls the drivers constantly to obtain status information. So
far when testing no error has created a false status report. But this is
possible if errors are not detected by the CRC code. It may make sense to change
things so that this polling is optional (can probably be done using the
current M569 R option), the UART interface would then in effect only be
used for configuration.